### PR TITLE
Add Supabase-backed create building E2E test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,3 +216,50 @@ jobs:
 
       - name: Run bottom-up local suite
         run: pnpm run test:bottom-up:local
+
+  e2e:
+    name: E2E (Playwright + Supabase)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.0.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "pnpm"
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Setup Supabase CLI
+        uses: supabase/setup-cli@v2
+        with:
+          version: latest
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+        env:
+          DATABASE_URL: "postgresql://dummy:dummy@localhost:5432/dummy"
+
+      - name: Install Playwright browser
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Start Supabase local emulator
+        run: |
+          if [ ! -f supabase/config.toml ]; then
+            supabase init --yes
+          fi
+          # This repository's supabase/seed.sql targets app tables managed by Prisma test harness, not Supabase local migrations.
+          # Move it out of the way for this CI job so Supabase local Auth can start cleanly.
+          if [ -f supabase/seed.sql ]; then
+            mv supabase/seed.sql supabase/seed.sql.ci.bak
+          fi
+          supabase start -x studio,imgproxy,mailpit,edge-runtime,logflare,vector,supavisor --ignore-health-check
+
+      - name: Run Playwright E2E tests
+        run: pnpm run test:e2e:supabase

--- a/README.md
+++ b/README.md
@@ -338,22 +338,13 @@ supabase start
 supabase status
 ```
 
-Set the local Supabase values reported by `supabase status`:
-
-```powershell
-$env:DATABASE_URL = "postgresql://postgres:postgres@127.0.0.1:54322/postgres"
-$env:SUPABASE_URL = "http://127.0.0.1:54321"
-$env:SUPABASE_ANON_KEY = "<local anon key>"
-$env:SUPABASE_SERVICE_ROLE_KEY = "<local service role key>"
-```
-
 Run the create-building E2E test:
 
 ```powershell
 corepack pnpm run test:e2e:supabase -- tests/e2e/buildings/create-building.e2e.spec.ts
 ```
 
-The Supabase E2E launcher runs `prisma db push --accept-data-loss` before starting the core API. It does not run `supabase/seed.sql`; keep that seed aligned with the current Prisma schema before using `supabase db reset`.
+The Supabase E2E launcher reads `supabase status -o env` and maps the local `DB_URL`, `API_URL`, `ANON_KEY`, and `SERVICE_ROLE_KEY` into the app environment automatically. It also runs `prisma db push --accept-data-loss` before starting the core API. It does not run `supabase/seed.sql`; keep that seed aligned with the current Prisma schema before using `supabase db reset`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -327,6 +327,34 @@ pnpm --filter @optigrid/frontend run test
 pnpm --filter @optigrid/core run test
 ```
 
+### Run Building E2E Tests with Local Supabase
+
+Use this flow when you want Playwright to test against the local Supabase emulator instead of the temporary Postgres container used by the default E2E launcher.
+
+```powershell
+# Start local Supabase. If this repo has not been initialized locally yet,
+# run `supabase init` once from the repo root first.
+supabase start
+supabase status
+```
+
+Set the local Supabase values reported by `supabase status`:
+
+```powershell
+$env:DATABASE_URL = "postgresql://postgres:postgres@127.0.0.1:54322/postgres"
+$env:SUPABASE_URL = "http://127.0.0.1:54321"
+$env:SUPABASE_ANON_KEY = "<local anon key>"
+$env:SUPABASE_SERVICE_ROLE_KEY = "<local service role key>"
+```
+
+Run the create-building E2E test:
+
+```powershell
+corepack pnpm run test:e2e:supabase -- tests/e2e/buildings/create-building.e2e.spec.ts
+```
+
+The Supabase E2E launcher runs `prisma db push --accept-data-loss` before starting the core API. It does not run `supabase/seed.sql`; keep that seed aligned with the current Prisma schema before using `supabase db reset`.
+
 ---
 
 ## Branching Strategy

--- a/backend/core/src/middleware/auth.middleware.ts
+++ b/backend/core/src/middleware/auth.middleware.ts
@@ -60,16 +60,38 @@ type SessionPayload = {
 	email?: string;
 };
 
+function parseJsonSessionPayload(value: string): SessionPayload | null {
+	try {
+		return JSON.parse(value) as SessionPayload;
+	} catch {
+		return null;
+	}
+}
+
 function parseSessionPayload(rawSession: string | null): SessionPayload | null {
 	if (!rawSession) {
 		return null;
 	}
 
-	try {
-		return JSON.parse(rawSession) as SessionPayload;
-	} catch {
-		return null;
+	let candidate = rawSession;
+	for (let attempt = 0; attempt < 3; attempt += 1) {
+		const parsed = parseJsonSessionPayload(candidate);
+		if (parsed) {
+			return parsed;
+		}
+
+		try {
+			const decoded = decodeURIComponent(candidate);
+			if (decoded === candidate) {
+				return null;
+			}
+			candidate = decoded;
+		} catch {
+			return null;
+		}
 	}
+
+	return null;
 }
 
 async function trySessionCookieAuth(req: Request): Promise<boolean> {

--- a/frontend/app/api/auth/login/route.ts
+++ b/frontend/app/api/auth/login/route.ts
@@ -48,9 +48,7 @@ export async function POST(request: Request) {
 		const lastName = typeof maybeUser?.lastName === "string" ? maybeUser.lastName : "";
 
 		if (coreResponse.ok && userId && emailValue) {
-			const sessionPayload = encodeURIComponent(
-				JSON.stringify({ userId, email: emailValue, firstName, lastName })
-			);
+			const sessionPayload = JSON.stringify({ userId, email: emailValue, firstName, lastName });
 			response.cookies.set(SESSION_COOKIE_NAME, sessionPayload, {
 				httpOnly: true,
 				secure: process.env.NODE_ENV === "production",

--- a/frontend/app/api/auth/signup/route.ts
+++ b/frontend/app/api/auth/signup/route.ts
@@ -1,6 +1,9 @@
 import { NextResponse } from "next/server";
 
 const CORE_URL = process.env.CORE_URL ?? "http://localhost:4000";
+const SESSION_COOKIE_NAME = "optigrid_session";
+const ACCESS_TOKEN_COOKIE_NAME = "optigrid_access_token";
+const SESSION_MAX_AGE_SECONDS = 60 * 60 * 12;
 
 type SignupBody = {
     email?: unknown;
@@ -9,6 +12,39 @@ type SignupBody = {
     firstName?: unknown;
     lastName?: unknown;
 };
+
+function setAuthCookies(response: NextResponse, payload: Record<string, unknown>) {
+    const maybeUser = payload.user as Record<string, unknown> | undefined;
+    const userId = typeof maybeUser?.userId === "string" ? maybeUser.userId : "";
+    const emailValue = typeof maybeUser?.email === "string" ? maybeUser.email : "";
+    const firstName = typeof maybeUser?.firstName === "string" ? maybeUser.firstName : "";
+    const lastName = typeof maybeUser?.lastName === "string" ? maybeUser.lastName : "";
+
+    if (userId && emailValue) {
+        response.cookies.set(
+            SESSION_COOKIE_NAME,
+            JSON.stringify({ userId, email: emailValue, firstName, lastName }),
+            {
+                httpOnly: true,
+                secure: process.env.NODE_ENV === "production",
+                sameSite: "lax",
+                path: "/",
+                maxAge: SESSION_MAX_AGE_SECONDS,
+            }
+        );
+    }
+
+    const accessToken = typeof payload.accessToken === "string" ? payload.accessToken : "";
+    if (accessToken) {
+        response.cookies.set(ACCESS_TOKEN_COOKIE_NAME, accessToken, {
+            httpOnly: true,
+            secure: process.env.NODE_ENV === "production",
+            sameSite: "lax",
+            path: "/",
+            maxAge: SESSION_MAX_AGE_SECONDS,
+        });
+    }
+}
 
 export async function POST(request: Request) {
     let body: SignupBody;
@@ -42,11 +78,30 @@ export async function POST(request: Request) {
             cache: "no-store",
         });
 
-        const payload = await coreResponse.json().catch(() => ({
+        const payload = (await coreResponse.json().catch(() => ({
             message: coreResponse.ok ? "User created successfully" : "Signup failed",
-        }));
+        }))) as Record<string, unknown>;
 
-        return NextResponse.json(payload, { status: coreResponse.status });
+        if (!coreResponse.ok) {
+            return NextResponse.json(payload, { status: coreResponse.status });
+        }
+
+        const loginResponse = await fetch(`${CORE_URL}/auth/login`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ email, password }),
+            cache: "no-store",
+        });
+        const loginPayload = (await loginResponse.json().catch(() => payload)) as Record<string, unknown>;
+        const responsePayload = loginResponse.ok ? loginPayload : payload;
+        const responseStatus = loginResponse.ok ? coreResponse.status : 502;
+        const response = NextResponse.json(responsePayload, { status: responseStatus });
+
+        if (loginResponse.ok) {
+            setAuthCookies(response, loginPayload);
+        }
+
+        return response;
     } catch {
         return NextResponse.json({ message: "Unable to reach authentication service." }, { status: 502 });
     }

--- a/frontend/lib/session.ts
+++ b/frontend/lib/session.ts
@@ -7,16 +7,33 @@ export type SessionUser = {
 
 export const SESSION_COOKIE_NAME = "optigrid_session";
 
+function parseJsonSession(value: string): Partial<SessionUser> | null {
+	try {
+		return JSON.parse(value) as Partial<SessionUser>;
+	} catch {
+		return null;
+	}
+}
+
 export function parseSession(rawValue: string | undefined): SessionUser | null {
 	if (!rawValue) {
 		return null;
 	}
 
-	try {
-		const decoded = decodeURIComponent(rawValue);
-		const parsed = JSON.parse(decoded) as Partial<SessionUser>;
-		if (!parsed.userId || !parsed.email) {
-			return null;
+	let candidate = rawValue;
+	for (let attempt = 0; attempt < 3; attempt += 1) {
+		const parsed = parseJsonSession(candidate);
+		if (!parsed?.userId || !parsed.email) {
+			try {
+				const decoded = decodeURIComponent(candidate);
+				if (decoded === candidate) {
+					return null;
+				}
+				candidate = decoded;
+				continue;
+			} catch {
+				return null;
+			}
 		}
 
 		return {
@@ -25,9 +42,9 @@ export function parseSession(rawValue: string | undefined): SessionUser | null {
 			firstName: parsed.firstName ?? "",
 			lastName: parsed.lastName ?? "",
 		};
-	} catch {
-		return null;
 	}
+
+	return null;
 }
 
 export function buildDisplayName(user: Pick<SessionUser, "firstName" | "lastName" | "email">): string {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
 		"test:python": "PYTHONPATH=. pytest tests/unit/ingestion/ -v && PYTHONPATH=. pytest tests/unit/analytics/ -v",
 		"test:all": "pnpm test:node && pnpm test:python",
 		"test:e2e": "playwright test --config playwright.config.ts",
+		"test:e2e:supabase": "node scripts/e2e-local-supabase.mjs",
 		"storybook": "corepack pnpm --filter ./frontend run storybook",
 		"storybook:build": "corepack pnpm --filter ./frontend run build-storybook",
 		"stack:up": "node scripts/docker-stack-up.mjs",

--- a/scripts/e2e-core-server.mjs
+++ b/scripts/e2e-core-server.mjs
@@ -2,9 +2,16 @@ import { spawn, spawnSync } from "node:child_process";
 import { GenericContainer, Wait } from "testcontainers";
 
 const CORE_PORT = process.env.PORT ?? "4000";
+const USE_LOCAL_SUPABASE = process.env.E2E_USE_LOCAL_SUPABASE === "1";
 const PG_USER = "optigrid_e2e_user";
 const PG_PASSWORD = "optigrid_e2e_password";
 const PG_DB = `optigrid_e2e_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+const REQUIRED_LOCAL_SUPABASE_ENV = [
+  "DATABASE_URL",
+  "SUPABASE_URL",
+  "SUPABASE_ANON_KEY",
+  "SUPABASE_SERVICE_ROLE_KEY",
+];
 
 function runOrExit(command, args, env) {
   const result = spawnSync(command, args, {
@@ -20,6 +27,48 @@ function runOrExit(command, args, env) {
   if (result.status !== 0) {
     throw new Error(`${command} ${args.join(" ")} failed with status ${result.status}`);
   }
+}
+
+function requireLocalSupabaseEnv() {
+  const missing = REQUIRED_LOCAL_SUPABASE_ENV.filter(
+    (name) => !process.env[name]?.trim()
+  );
+
+  if (missing.length > 0) {
+    throw new Error(
+      `E2E_USE_LOCAL_SUPABASE=1 requires ${missing.join(", ")}. ` +
+        "Run `supabase status` and export the local database/auth values before starting Playwright."
+    );
+  }
+}
+
+function pushPrismaSchema(env) {
+  runOrExit(
+    "corepack",
+    [
+      "pnpm",
+      "--filter",
+      "@optigrid/core",
+      "exec",
+      "prisma",
+      "db",
+      "push",
+      "--accept-data-loss",
+    ],
+    env
+  );
+}
+
+function startCoreServer(env) {
+  return spawn(
+    "corepack",
+    ["pnpm", "--filter", "@optigrid/core", "run", "dev"],
+    {
+      stdio: "inherit",
+      shell: true,
+      env,
+    }
+  );
 }
 
 async function main() {
@@ -52,53 +101,36 @@ async function main() {
   });
 
   try {
-    container = await new GenericContainer("postgres:16-alpine")
-      .withEnvironment({
-        POSTGRES_USER: PG_USER,
-        POSTGRES_PASSWORD: PG_PASSWORD,
-        POSTGRES_DB: PG_DB,
-      })
-      .withExposedPorts(5432)
-      .withWaitStrategy(
-        Wait.forAll([
-          Wait.forListeningPorts(),
-          Wait.forLogMessage("database system is ready to accept connections", 2),
-        ])
-      )
-      .withStartupTimeout(120_000)
-      .start();
-
-    const databaseUrl = `postgresql://${PG_USER}:${PG_PASSWORD}@${container.getHost()}:${container.getMappedPort(5432)}/${PG_DB}`;
     const serviceEnv = {
       ...process.env,
       PORT: CORE_PORT,
-      DATABASE_URL: databaseUrl,
     };
 
-    runOrExit(
-      "corepack",
-      [
-        "pnpm",
-        "--filter",
-        "@optigrid/core",
-        "exec",
-        "prisma",
-        "db",
-        "push",
-        "--accept-data-loss",
-      ],
-      serviceEnv
-    );
+    if (USE_LOCAL_SUPABASE) {
+      requireLocalSupabaseEnv();
+      console.log("[e2e-core] using local Supabase database and auth services");
+    } else {
+      container = await new GenericContainer("postgres:16-alpine")
+        .withEnvironment({
+          POSTGRES_USER: PG_USER,
+          POSTGRES_PASSWORD: PG_PASSWORD,
+          POSTGRES_DB: PG_DB,
+        })
+        .withExposedPorts(5432)
+        .withWaitStrategy(
+          Wait.forAll([
+            Wait.forListeningPorts(),
+            Wait.forLogMessage("database system is ready to accept connections", 2),
+          ])
+        )
+        .withStartupTimeout(120_000)
+        .start();
 
-    coreProcess = spawn(
-      "corepack",
-      ["pnpm", "--filter", "@optigrid/core", "run", "dev"],
-      {
-        stdio: "inherit",
-        shell: true,
-        env: serviceEnv,
-      }
-    );
+      serviceEnv.DATABASE_URL = `postgresql://${PG_USER}:${PG_PASSWORD}@${container.getHost()}:${container.getMappedPort(5432)}/${PG_DB}`;
+    }
+
+    pushPrismaSchema(serviceEnv);
+    coreProcess = startCoreServer(serviceEnv);
 
     coreProcess.on("exit", (code) => {
       void shutdown(code ?? 1);

--- a/scripts/e2e-core-server.mjs
+++ b/scripts/e2e-core-server.mjs
@@ -59,6 +59,21 @@ function pushPrismaSchema(env) {
   );
 }
 
+function generatePrismaClient(env) {
+  runOrExit(
+    "corepack",
+    [
+      "pnpm",
+      "--filter",
+      "@optigrid/core",
+      "exec",
+      "prisma",
+      "generate",
+    ],
+    env
+  );
+}
+
 function startCoreServer(env) {
   return spawn(
     "corepack",
@@ -103,6 +118,7 @@ async function main() {
   try {
     const serviceEnv = {
       ...process.env,
+      NODE_ENV: "test",
       PORT: CORE_PORT,
     };
 
@@ -130,6 +146,7 @@ async function main() {
     }
 
     pushPrismaSchema(serviceEnv);
+    generatePrismaClient(serviceEnv);
     coreProcess = startCoreServer(serviceEnv);
 
     coreProcess.on("exit", (code) => {

--- a/scripts/e2e-local-supabase.mjs
+++ b/scripts/e2e-local-supabase.mjs
@@ -1,8 +1,96 @@
 import { spawnSync } from "node:child_process";
 
+const REQUIRED_E2E_ENV = [
+  "DATABASE_URL",
+  "SUPABASE_URL",
+  "SUPABASE_ANON_KEY",
+  "SUPABASE_SERVICE_ROLE_KEY",
+];
+
 const forwardedArgs = process.argv.slice(2);
 if (forwardedArgs[0] === "--") {
   forwardedArgs.shift();
+}
+
+function parseEnvOutput(output) {
+  const values = {};
+
+  for (const line of output.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#") || !trimmed.includes("=")) {
+      continue;
+    }
+
+    const [rawName, ...rawValueParts] = trimmed.split("=");
+    const name = rawName.trim();
+    let value = rawValueParts.join("=").trim();
+
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+
+    values[name] = value;
+  }
+
+  return values;
+}
+
+function readLocalSupabaseEnv() {
+  const status = spawnSync("supabase", ["status", "-o", "env"], {
+    encoding: "utf8",
+    shell: true,
+    env: {
+      ...process.env,
+      SUPABASE_NO_TELEMETRY: "1",
+    },
+  });
+
+  if (status.error) {
+    throw status.error;
+  }
+
+  if (status.status !== 0) {
+    const output = [status.stdout, status.stderr].filter(Boolean).join("\n").trim();
+    throw new Error(
+      "Unable to read local Supabase status. Run `supabase start` first." +
+        (output ? `\n\n${output}` : "")
+    );
+  }
+
+  const supabaseEnv = parseEnvOutput(status.stdout);
+  const resolvedEnv = {
+    DATABASE_URL: supabaseEnv.DB_URL ?? supabaseEnv.DATABASE_URL,
+    SUPABASE_URL: supabaseEnv.API_URL ?? supabaseEnv.SUPABASE_URL,
+    SUPABASE_ANON_KEY: supabaseEnv.ANON_KEY ?? supabaseEnv.SUPABASE_ANON_KEY,
+    SUPABASE_SERVICE_ROLE_KEY:
+      supabaseEnv.SERVICE_ROLE_KEY ?? supabaseEnv.SUPABASE_SERVICE_ROLE_KEY,
+  };
+
+  const missing = REQUIRED_E2E_ENV.filter((name) => !resolvedEnv[name]?.trim());
+  if (missing.length > 0) {
+    throw new Error(
+      `Local Supabase status did not include ${missing.join(", ")}. ` +
+        "Check `supabase status -o env` output."
+    );
+  }
+
+  return resolvedEnv;
+}
+
+function exitWithError(error) {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(message);
+  process.exit(1);
+}
+
+let localSupabaseEnv;
+try {
+  localSupabaseEnv = readLocalSupabaseEnv();
+} catch (error) {
+  exitWithError(error);
 }
 
 const playwrightArgs = [
@@ -20,12 +108,13 @@ const result = spawnSync("corepack", playwrightArgs, {
   shell: true,
   env: {
     ...process.env,
+    ...localSupabaseEnv,
     E2E_USE_LOCAL_SUPABASE: "1",
   },
 });
 
 if (result.error) {
-  throw result.error;
+  exitWithError(result.error);
 }
 
 process.exit(result.status ?? 1);

--- a/scripts/e2e-local-supabase.mjs
+++ b/scripts/e2e-local-supabase.mjs
@@ -1,0 +1,31 @@
+import { spawnSync } from "node:child_process";
+
+const forwardedArgs = process.argv.slice(2);
+if (forwardedArgs[0] === "--") {
+  forwardedArgs.shift();
+}
+
+const playwrightArgs = [
+  "pnpm",
+  "exec",
+  "playwright",
+  "test",
+  "--config",
+  "playwright.config.ts",
+  ...forwardedArgs,
+];
+
+const result = spawnSync("corepack", playwrightArgs, {
+  stdio: "inherit",
+  shell: true,
+  env: {
+    ...process.env,
+    E2E_USE_LOCAL_SUPABASE: "1",
+  },
+});
+
+if (result.error) {
+  throw result.error;
+}
+
+process.exit(result.status ?? 1);

--- a/tests/e2e/auth/login.e2e.spec.ts
+++ b/tests/e2e/auth/login.e2e.spec.ts
@@ -53,9 +53,9 @@ test.describe("Login page", () => {
 
   test("shows API error for invalid credentials", async ({ page }) => {
     await page.goto("/login");
-    await page.getByPlaceholder("Email").fill("invalid@optigrid.test");
-    await page.getByPlaceholder("Password").fill("BadPass123!");
-    await page.getByRole("button", { name: "Login" }).click();
+    await page.getByLabel("Work email").fill("invalid@optigrid.test");
+    await page.getByLabel("Password").fill("BadPass123!");
+    await page.getByRole("button", { name: "Log in" }).click();
 
     await expect(page.getByText("Invalid email or password")).toBeVisible();
   });
@@ -65,11 +65,16 @@ test.describe("Login page", () => {
     await createUserInCore(request, user);
 
     await page.goto("/login");
-    await page.getByPlaceholder("Email").fill(user.email);
-    await page.getByPlaceholder("Password").fill(user.password);
-    await page.getByRole("button", { name: "Login" }).click();
+    await page.getByLabel("Work email").fill(user.email);
+    await page.getByLabel("Password").fill(user.password);
+    const loginResponsePromise = page.waitForResponse("**/api/auth/login");
+    await page.getByRole("button", { name: "Log in" }).click();
+    const loginResponse = await loginResponsePromise;
+    expect(loginResponse.ok()).toBeTruthy();
 
-    await expect(page).toHaveURL(/\/dashboard$/);
-    await expect(page.getByRole("heading", { name: "Dashboard" })).toBeVisible();
+    await expect(page).toHaveURL(/\/dashboard$/, { timeout: 15_000 });
+    await expect(
+      page.getByRole("heading", { name: `Welcome back, ${user.firstName}` })
+    ).toBeVisible();
   });
 });

--- a/tests/e2e/auth/signup.e2e.spec.ts
+++ b/tests/e2e/auth/signup.e2e.spec.ts
@@ -53,15 +53,20 @@ test.describe("Signup page", () => {
 		const user = buildUniqueUser();
 
 		await page.goto("/signup");
-		await page.getByLabel("First Name").fill(user.firstName);
-		await page.getByLabel("Last Name").fill(user.lastName);
-		await page.getByLabel("Email Address").fill(user.email);
+		await page.getByLabel("First name").fill(user.firstName);
+		await page.getByLabel("Last name").fill(user.lastName);
+		await page.getByLabel("Work email").fill(user.email);
 		await page.getByLabel("Password", { exact: true }).fill(user.password);
-		await page.getByLabel("Confirm Password", { exact: true }).fill(user.password);
+		await page.getByLabel("Confirm password", { exact: true }).fill(user.password);
+		const signupResponsePromise = page.waitForResponse("**/api/auth/signup");
 		await page.getByRole("button", { name: "Create account" }).click();
+		const signupResponse = await signupResponsePromise;
+		expect(signupResponse.ok()).toBeTruthy();
 
-		await expect(page).toHaveURL(/\/dashboard$/);
-		await expect(page.getByRole("heading", { name: "Dashboard" })).toBeVisible();
+		await expect(page).toHaveURL(/\/dashboard$/, { timeout: 15_000 });
+		await expect(
+			page.getByRole("heading", { name: `Welcome back, ${user.firstName}` })
+		).toBeVisible();
 	});
 
 	test("shows duplicate-user error returned by backend", async ({ page, request }) => {
@@ -69,11 +74,11 @@ test.describe("Signup page", () => {
 		await createUserInCore(request, user);
 
 		await page.goto("/signup");
-		await page.getByLabel("First Name").fill(user.firstName);
-		await page.getByLabel("Last Name").fill(user.lastName);
-		await page.getByLabel("Email Address").fill(user.email);
+		await page.getByLabel("First name").fill(user.firstName);
+		await page.getByLabel("Last name").fill(user.lastName);
+		await page.getByLabel("Work email").fill(user.email);
 		await page.getByLabel("Password", { exact: true }).fill(user.password);
-		await page.getByLabel("Confirm Password", { exact: true }).fill(user.password);
+		await page.getByLabel("Confirm password", { exact: true }).fill(user.password);
 		await page.getByRole("button", { name: "Create account" }).click();
 
 		await expect(page.getByText("User already exists, please login instead.")).toBeVisible();

--- a/tests/e2e/buildings/create-building.e2e.spec.ts
+++ b/tests/e2e/buildings/create-building.e2e.spec.ts
@@ -54,9 +54,12 @@ test.describe("Create building", () => {
     await page.goto("/login");
     await page.getByLabel("Work email").fill(user.email);
     await page.getByLabel("Password").fill(user.password);
+    const loginResponsePromise = page.waitForResponse("**/api/auth/login");
     await page.getByRole("button", { name: "Log in" }).click();
+    const loginResponse = await loginResponsePromise;
+    expect(loginResponse.ok()).toBeTruthy();
 
-    await expect(page).toHaveURL(/\/dashboard$/);
+    await expect(page).toHaveURL(/\/dashboard$/, { timeout: 15_000 });
 
     await page.getByRole("link", { name: "+ Add building" }).click();
     await expect(page).toHaveURL(/\/buildings\/add$/);

--- a/tests/e2e/buildings/create-building.e2e.spec.ts
+++ b/tests/e2e/buildings/create-building.e2e.spec.ts
@@ -1,0 +1,76 @@
+import { expect, test, type APIRequestContext } from "@playwright/test";
+
+const CORE_BASE_URL = process.env.E2E_CORE_URL ?? "http://localhost:4000";
+
+type E2EUser = {
+  email: string;
+  password: string;
+  name: string;
+};
+
+function uniqueSuffix(): string {
+  return `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function buildUniqueUser(): E2EUser {
+  const suffix = uniqueSuffix();
+  return {
+    email: `create-building-e2e-${suffix}@optigrid.test`,
+    password: "StrongPass123!",
+    name: "Avery Building",
+  };
+}
+
+async function createUserInCore(
+  request: APIRequestContext,
+  user: E2EUser
+): Promise<void> {
+  const response = await request.post(`${CORE_BASE_URL}/auth/signup`, {
+    data: {
+      email: user.email,
+      password: user.password,
+      name: user.name,
+    },
+  });
+
+  const payload = await response.json().catch(() => ({}));
+  expect(
+    response.ok(),
+    `Expected signup seed to succeed, got ${response.status()} with payload ${JSON.stringify(payload)}`
+  ).toBeTruthy();
+}
+
+test.describe("Create building", () => {
+  test("creates a building from the Add Building page", async ({
+    page,
+    request,
+  }) => {
+    const user = buildUniqueUser();
+    const buildingName = `E2E Create Building ${uniqueSuffix()}`;
+    const buildingAddress = "1 Maude St, Sandton, 2196";
+
+    await createUserInCore(request, user);
+
+    await page.goto("/login");
+    await page.getByLabel("Work email").fill(user.email);
+    await page.getByLabel("Password").fill(user.password);
+    await page.getByRole("button", { name: "Log in" }).click();
+
+    await expect(page).toHaveURL(/\/dashboard$/);
+
+    await page.getByRole("link", { name: "+ Add building" }).click();
+    await expect(page).toHaveURL(/\/buildings\/add$/);
+
+    await page.getByLabel(/Building name/).fill(buildingName);
+    await page.getByLabel("Building type").selectOption("Commercial");
+    await page.getByLabel("Physical address").fill(buildingAddress);
+    await page.getByLabel(/Floor area/).fill("5000");
+    await page.getByLabel("Max occupancy").fill("200");
+    await page.getByLabel("Timezone").fill("Africa/Johannesburg");
+    await page.getByRole("button", { name: "Add building" }).click();
+
+    await expect(page).toHaveURL(/\/dashboard$/);
+    await expect(page.locator("tbody").getByText(buildingName)).toBeVisible();
+    await expect(page.locator("tbody").getByText(buildingAddress)).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary

- Added Supabase-local support for Playwright E2E runs.
- Added the #149 create building E2E flow.
- Updated auth/session handling so signup and login work reliably in E2E.
- Updated existing auth E2E selectors to match the current UI.

## Testing

- `corepack pnpm run test:e2e:supabase`

Result:

- 7 passed