### PR TITLE
 Add building list, edit, and delete E2E flows

### DIFF
--- a/tests/e2e/buildings/delete-building.e2e.spec.ts
+++ b/tests/e2e/buildings/delete-building.e2e.spec.ts
@@ -1,0 +1,146 @@
+import { expect, test, type APIRequestContext } from "@playwright/test";
+
+const CORE_BASE_URL = process.env.E2E_CORE_URL ?? "http://localhost:4000";
+
+type E2EUser = {
+  email: string;
+  password: string;
+  name: string;
+};
+
+type BuildingSeed = {
+  name: string;
+  address: string;
+};
+
+function uniqueSuffix(): string {
+  return `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function buildUniqueUser(): E2EUser {
+  const suffix = uniqueSuffix();
+  return {
+    email: `delete-building-e2e-${suffix}@optigrid.test`,
+    password: "StrongPass123!",
+    name: "Avery Building",
+  };
+}
+
+async function createUserInCore(
+  request: APIRequestContext,
+  user: E2EUser
+): Promise<void> {
+  const response = await request.post(`${CORE_BASE_URL}/auth/signup`, {
+    data: {
+      email: user.email,
+      password: user.password,
+      name: user.name,
+    },
+  });
+
+  const payload = await response.json().catch(() => ({}));
+  expect(
+    response.ok(),
+    `Expected signup seed to succeed, got ${response.status()} with payload ${JSON.stringify(payload)}`
+  ).toBeTruthy();
+}
+
+async function loginInCore(
+  request: APIRequestContext,
+  user: E2EUser
+): Promise<string> {
+  const response = await request.post(`${CORE_BASE_URL}/auth/login`, {
+    data: {
+      email: user.email,
+      password: user.password,
+    },
+  });
+
+  const payload = (await response.json().catch(() => ({}))) as {
+    accessToken?: unknown;
+  };
+  expect(
+    response.ok(),
+    `Expected login seed to succeed, got ${response.status()} with payload ${JSON.stringify(payload)}`
+  ).toBeTruthy();
+  expect(typeof payload.accessToken).toBe("string");
+
+  return payload.accessToken as string;
+}
+
+async function createBuildingInCore(
+  request: APIRequestContext,
+  accessToken: string,
+  building: BuildingSeed
+): Promise<void> {
+  const response = await request.post(`${CORE_BASE_URL}/api/buildings`, {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      "Idempotency-Key": `delete-building-e2e-${uniqueSuffix()}`,
+    },
+    data: {
+      building_name: building.name,
+      building_type: "Commercial",
+      square_footage: 5000,
+      physical_address: building.address,
+      timezone: "Africa/Johannesburg",
+      max_occupancy: 200,
+    },
+  });
+
+  const payload = await response.json().catch(() => ({}));
+  expect(
+    response.ok(),
+    `Expected building seed to succeed, got ${response.status()} with payload ${JSON.stringify(payload)}`
+  ).toBeTruthy();
+}
+
+test.describe("Delete building", () => {
+  test("deletes a building from the dashboard delete action", async ({
+    page,
+    request,
+  }) => {
+    const user = buildUniqueUser();
+    const building = {
+      name: `E2E Delete Building ${uniqueSuffix()}`,
+      address: "6 Maude St, Sandton, 2196",
+    };
+
+    await createUserInCore(request, user);
+    const accessToken = await loginInCore(request, user);
+    await createBuildingInCore(request, accessToken, building);
+
+    await page.goto("/login");
+    await page.getByLabel("Work email").fill(user.email);
+    await page.getByLabel("Password").fill(user.password);
+    const loginResponsePromise = page.waitForResponse("**/api/auth/login");
+    await page.getByRole("button", { name: "Log in" }).click();
+    const loginResponse = await loginResponsePromise;
+    expect(loginResponse.ok()).toBeTruthy();
+
+    await expect(page).toHaveURL(/\/dashboard$/, { timeout: 15_000 });
+    const buildingRow = page.locator("tbody tr").filter({
+      hasText: building.name,
+    });
+    await expect(buildingRow).toBeVisible();
+    await expect(buildingRow).toContainText(building.address);
+
+    await buildingRow
+      .getByRole("button", { name: `Delete ${building.name}` })
+      .click();
+
+    const deleteModal = page.locator(".modal");
+    await expect(deleteModal.getByRole("heading", { name: "Delete building" })).toBeVisible();
+    await expect(deleteModal.getByText(building.name)).toBeVisible();
+
+    const deleteResponsePromise = page.waitForResponse((response) => {
+      return response.url().includes("/api/buildings/") && response.request().method() === "DELETE";
+    });
+    await page.getByRole("button", { name: "Delete", exact: true }).click();
+    const deleteResponse = await deleteResponsePromise;
+    expect(deleteResponse.ok()).toBeTruthy();
+
+    await expect(page.getByText("No buildings yet.")).toBeVisible();
+    await expect(page.getByText(building.name)).toHaveCount(0);
+  });
+});

--- a/tests/e2e/buildings/edit-building.e2e.spec.ts
+++ b/tests/e2e/buildings/edit-building.e2e.spec.ts
@@ -1,0 +1,177 @@
+import { expect, test, type APIRequestContext } from "@playwright/test";
+
+const CORE_BASE_URL = process.env.E2E_CORE_URL ?? "http://localhost:4000";
+
+type E2EUser = {
+  email: string;
+  password: string;
+  name: string;
+};
+
+type BuildingSeed = {
+  name: string;
+  address: string;
+  squareFootage: number;
+  maxOccupancy: number;
+};
+
+function uniqueSuffix(): string {
+  return `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function buildUniqueUser(): E2EUser {
+  const suffix = uniqueSuffix();
+  return {
+    email: `edit-building-e2e-${suffix}@optigrid.test`,
+    password: "StrongPass123!",
+    name: "Avery Building",
+  };
+}
+
+async function createUserInCore(
+  request: APIRequestContext,
+  user: E2EUser
+): Promise<void> {
+  const response = await request.post(`${CORE_BASE_URL}/auth/signup`, {
+    data: {
+      email: user.email,
+      password: user.password,
+      name: user.name,
+    },
+  });
+
+  const payload = await response.json().catch(() => ({}));
+  expect(
+    response.ok(),
+    `Expected signup seed to succeed, got ${response.status()} with payload ${JSON.stringify(payload)}`
+  ).toBeTruthy();
+}
+
+async function loginInCore(
+  request: APIRequestContext,
+  user: E2EUser
+): Promise<string> {
+  const response = await request.post(`${CORE_BASE_URL}/auth/login`, {
+    data: {
+      email: user.email,
+      password: user.password,
+    },
+  });
+
+  const payload = (await response.json().catch(() => ({}))) as {
+    accessToken?: unknown;
+  };
+  expect(
+    response.ok(),
+    `Expected login seed to succeed, got ${response.status()} with payload ${JSON.stringify(payload)}`
+  ).toBeTruthy();
+  expect(typeof payload.accessToken).toBe("string");
+
+  return payload.accessToken as string;
+}
+
+async function createBuildingInCore(
+  request: APIRequestContext,
+  accessToken: string,
+  building: BuildingSeed
+): Promise<string> {
+  const response = await request.post(`${CORE_BASE_URL}/api/buildings`, {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      "Idempotency-Key": `edit-building-e2e-${uniqueSuffix()}`,
+    },
+    data: {
+      building_name: building.name,
+      building_type: "Commercial",
+      square_footage: building.squareFootage,
+      physical_address: building.address,
+      timezone: "Africa/Johannesburg",
+      max_occupancy: building.maxOccupancy,
+    },
+  });
+
+  const payload = (await response.json().catch(() => ({}))) as {
+    data?: {
+      building_id?: unknown;
+    };
+  };
+  expect(
+    response.ok(),
+    `Expected building seed to succeed, got ${response.status()} with payload ${JSON.stringify(payload)}`
+  ).toBeTruthy();
+  expect(typeof payload.data?.building_id).toBe("string");
+
+  return payload.data?.building_id as string;
+}
+
+test.describe("Edit building", () => {
+  test("updates a building from the dashboard edit action", async ({
+    page,
+    request,
+  }) => {
+    const user = buildUniqueUser();
+    const originalBuilding = {
+      name: `E2E Edit Original ${uniqueSuffix()}`,
+      address: "4 Maude St, Sandton, 2196",
+      squareFootage: 5000,
+      maxOccupancy: 200,
+    };
+    const updatedBuilding = {
+      name: `E2E Edit Updated ${uniqueSuffix()}`,
+      address: "5 Maude St, Sandton, 2196",
+      squareFootage: "6500",
+      maxOccupancy: "250",
+      timezone: "Africa/Johannesburg",
+    };
+
+    await createUserInCore(request, user);
+    const accessToken = await loginInCore(request, user);
+    await createBuildingInCore(request, accessToken, originalBuilding);
+
+    await page.goto("/login");
+    await page.getByLabel("Work email").fill(user.email);
+    await page.getByLabel("Password").fill(user.password);
+    const loginResponsePromise = page.waitForResponse("**/api/auth/login");
+    await page.getByRole("button", { name: "Log in" }).click();
+    const loginResponse = await loginResponsePromise;
+    expect(loginResponse.ok()).toBeTruthy();
+
+    await expect(page).toHaveURL(/\/dashboard$/, { timeout: 15_000 });
+    const originalRow = page.locator("tbody tr").filter({
+      hasText: originalBuilding.name,
+    });
+    await expect(originalRow).toBeVisible();
+    await originalRow
+      .getByRole("link", { name: `Edit ${originalBuilding.name}` })
+      .click();
+
+    await expect(page).toHaveURL(/\/buildings\/[^/]+\/edit$/);
+    await expect(page.getByRole("heading", { name: "Edit Building" })).toBeVisible();
+    await expect(page.getByLabel("Building name")).toHaveValue(originalBuilding.name);
+
+    await page.getByLabel("Building name").fill(updatedBuilding.name);
+    await page.getByLabel("Address").fill(updatedBuilding.address);
+    await page.getByLabel("Square footage").fill(updatedBuilding.squareFootage);
+    await page.getByLabel("Max occupancy").fill(updatedBuilding.maxOccupancy);
+    await page.getByLabel("Timezone").fill(updatedBuilding.timezone);
+
+    const updateResponsePromise = page.waitForResponse((response) => {
+      return response.url().includes("/api/buildings/") && response.request().method() === "PATCH";
+    });
+    await page.getByRole("button", { name: "Save changes" }).click();
+    const updateResponse = await updateResponsePromise;
+    expect(updateResponse.ok()).toBeTruthy();
+
+    await expect(
+      page.getByText("Building updated successfully. Redirecting...")
+    ).toBeVisible();
+    await expect(page).toHaveURL(/\/dashboard$/, { timeout: 15_000 });
+
+    const updatedRow = page.locator("tbody tr").filter({
+      hasText: updatedBuilding.name,
+    });
+    await expect(updatedRow).toBeVisible();
+    await expect(updatedRow).toContainText(updatedBuilding.address);
+    await expect(page.locator("tbody")).not.toContainText(originalBuilding.name);
+  });
+});

--- a/tests/e2e/buildings/list-building.e2e.spec.ts
+++ b/tests/e2e/buildings/list-building.e2e.spec.ts
@@ -1,0 +1,142 @@
+import { expect, test, type APIRequestContext } from "@playwright/test";
+
+const CORE_BASE_URL = process.env.E2E_CORE_URL ?? "http://localhost:4000";
+
+type E2EUser = {
+  email: string;
+  password: string;
+  name: string;
+};
+
+type BuildingSeed = {
+  name: string;
+  address: string;
+};
+
+function uniqueSuffix(): string {
+  return `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function buildUniqueUser(prefix: string): E2EUser {
+  const suffix = uniqueSuffix();
+  return {
+    email: `${prefix}-${suffix}@optigrid.test`,
+    password: "StrongPass123!",
+    name: "Avery Building",
+  };
+}
+
+async function createUserInCore(
+  request: APIRequestContext,
+  user: E2EUser
+): Promise<void> {
+  const response = await request.post(`${CORE_BASE_URL}/auth/signup`, {
+    data: {
+      email: user.email,
+      password: user.password,
+      name: user.name,
+    },
+  });
+
+  const payload = await response.json().catch(() => ({}));
+  expect(
+    response.ok(),
+    `Expected signup seed to succeed, got ${response.status()} with payload ${JSON.stringify(payload)}`
+  ).toBeTruthy();
+}
+
+async function loginInCore(
+  request: APIRequestContext,
+  user: E2EUser
+): Promise<string> {
+  const response = await request.post(`${CORE_BASE_URL}/auth/login`, {
+    data: {
+      email: user.email,
+      password: user.password,
+    },
+  });
+
+  const payload = (await response.json().catch(() => ({}))) as {
+    accessToken?: unknown;
+  };
+  expect(
+    response.ok(),
+    `Expected login seed to succeed, got ${response.status()} with payload ${JSON.stringify(payload)}`
+  ).toBeTruthy();
+  expect(typeof payload.accessToken).toBe("string");
+
+  return payload.accessToken as string;
+}
+
+async function createBuildingInCore(
+  request: APIRequestContext,
+  accessToken: string,
+  building: BuildingSeed
+): Promise<void> {
+  const response = await request.post(`${CORE_BASE_URL}/api/buildings`, {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      "Idempotency-Key": `list-building-e2e-${uniqueSuffix()}`,
+    },
+    data: {
+      building_name: building.name,
+      building_type: "Commercial",
+      square_footage: 5000,
+      physical_address: building.address,
+      timezone: "Africa/Johannesburg",
+      max_occupancy: 200,
+    },
+  });
+
+  const payload = await response.json().catch(() => ({}));
+  expect(
+    response.ok(),
+    `Expected building seed to succeed, got ${response.status()} with payload ${JSON.stringify(payload)}`
+  ).toBeTruthy();
+}
+
+test.describe("List buildings", () => {
+  test("shows only the authenticated user's buildings on the dashboard", async ({
+    page,
+    request,
+  }) => {
+    const owner = buildUniqueUser("list-building-owner-e2e");
+    const otherUser = buildUniqueUser("list-building-other-e2e");
+    const visibleBuilding = {
+      name: `E2E Listed Building ${uniqueSuffix()}`,
+      address: "2 Maude St, Sandton, 2196",
+    };
+    const hiddenBuilding = {
+      name: `E2E Hidden Building ${uniqueSuffix()}`,
+      address: "3 Maude St, Sandton, 2196",
+    };
+
+    await createUserInCore(request, owner);
+    await createUserInCore(request, otherUser);
+
+    const ownerAccessToken = await loginInCore(request, owner);
+    const otherAccessToken = await loginInCore(request, otherUser);
+
+    await createBuildingInCore(request, ownerAccessToken, visibleBuilding);
+    await createBuildingInCore(request, otherAccessToken, hiddenBuilding);
+
+    await page.goto("/login");
+    await page.getByLabel("Work email").fill(owner.email);
+    await page.getByLabel("Password").fill(owner.password);
+    const loginResponsePromise = page.waitForResponse("**/api/auth/login");
+    await page.getByRole("button", { name: "Log in" }).click();
+    const loginResponse = await loginResponsePromise;
+    expect(loginResponse.ok()).toBeTruthy();
+
+    await expect(page).toHaveURL(/\/dashboard$/, { timeout: 15_000 });
+
+    const visibleRow = page.locator("tbody tr").filter({
+      hasText: visibleBuilding.name,
+    });
+    await expect(visibleRow).toBeVisible();
+    await expect(visibleRow).toContainText("Commercial");
+    await expect(visibleRow).toContainText(visibleBuilding.address);
+    await expect(page.locator("tbody")).not.toContainText(hiddenBuilding.name);
+    await expect(page.getByText("No buildings yet.")).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
## Summary

- Added an E2E test for listing buildings on the dashboard.
- Added an E2E test for editing a building from the dashboard action.
- Added an E2E test for deleting a building from the dashboard action.
- Verified the flows against the local Supabase-backed E2E environment.

## Testing

- `corepack pnpm run test:e2e:supabase`

Result:

- `10 passed`