### PR TITLE
Fix Supabase Auth Profile Reconciliation and Local Runtime Cleanup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,6 +5,9 @@
 
 # Node
 node_modules/
+**/node_modules/
+.pnpm-store/
+**/.pnpm-store/
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
@@ -35,8 +38,10 @@ build/
 
 # Testing
 coverage/
+**/coverage/
 .nyc_output/
 .pytest_cache/
+**/.pytest_cache/
 tests/
 *.test.ts
 *.test.js
@@ -47,9 +52,13 @@ test-results/
 
 # Build outputs
 dist/
+**/dist/
 .next/
+**/.next/
 out/
+**/out/
 build/
+**/build/
 
 # Environment files
 .env
@@ -70,6 +79,8 @@ scripts/
 *.hcl
 
 # Temporary files
+mlruns/
+supabase/.temp/
 *.tmp
 *.temp
 *.log

--- a/backend/core/src/routes/contact.routes.ts
+++ b/backend/core/src/routes/contact.routes.ts
@@ -1,69 +1,71 @@
 import { Router } from "express";
 import { handleSubmit } from "../controllers/contact.controller";
-import router from "./user_auth.routes";
+
+const router = Router();
 
 /**
  * @swagger
  * /api/contact:
- * post:
- * summary: Submit a new ticket for support
- * description: This takes a users' request for help and sends it as an email to our email via Resend API
- * tags:
- * - Suport
- * requestBody:
- * required: true
- * content:
- * application/json:
- * schema:
- * type: object
- * required:
- * - inquiryTYpe
- * - subject
- * - message
- * properties:
- * inquiryType:
- * type: string
- * description: Under which category the request falls under.
- * example: "Building"
- * subject:
- * type: string
- * description: The subject of the email.
- * example: "Can not create a building"
- * message:
- * type: string
- * description: Summary of the issue.
- * example: "I can not create a building, I do not know what is the issue."
- * responses:
- * 200:
- * description: Email succesfully received.
- * content:
- * application/json:
- * schema:
- * type: object
- * properties:
- * success: 
- * type: boolean:
- * example: true
- * message: 
- * type: string
- * example: "Ticket Recieved"
- * id: 
- * type: string
- * description: Unique id of each email to differentiate and search for them.
- * example: "5b304c4f-1234-5f56-4321-8dcb76cd1123"
- * 400:
- * description: Validation failure/API error
- * content:
- * application/json:
- * schema:
- * type: object
- * properties:
- * success:
- * type: boolean
- * example: false
- * error:
- * type: string
- * example: "Failed to send: API key is missing or invalid"
+ *   post:
+ *     summary: Submit a support ticket
+ *     description: Sends a contact/support request email through Resend.
+ *     tags:
+ *       - Support
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - inquiryType
+ *               - subject
+ *               - message
+ *             properties:
+ *               inquiryType:
+ *                 type: string
+ *                 description: Category for the support request.
+ *                 example: Building
+ *               subject:
+ *                 type: string
+ *                 description: Email subject.
+ *                 example: Cannot create a building
+ *               message:
+ *                 type: string
+ *                 description: Summary of the issue.
+ *                 example: I cannot create a building and need help.
+ *     responses:
+ *       200:
+ *         description: Ticket email accepted.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *                   example: true
+ *                 message:
+ *                   type: string
+ *                   example: Recieved the ticket
+ *                 id:
+ *                   type: string
+ *                   description: Email provider id for the submitted ticket.
+ *                   example: 5b304c4f-1234-5f56-4321-8dcb76cd1123
+ *       400:
+ *         description: Validation failure or email provider error.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *                   example: false
+ *                 error:
+ *                   type: string
+ *                   example: "Failed to send: API key is missing or invalid"
  */
-router.post('/', handleSubmit);
+router.post("/", handleSubmit);
+
 export default router;

--- a/backend/core/src/services/contact.services.ts
+++ b/backend/core/src/services/contact.services.ts
@@ -3,7 +3,7 @@ import { Resend } from "resend";
 let resend: Resend | undefined;
 
 function getResendClient(): Resend {
-    const api = process.env.RESEND_API_KEY;
+    const api = process.env.NODE_ENV === "test" ? "dummy" : process.env.RESEND_API_KEY;
 
     if (!api) {
         throw new Error("Missing RESEND_API_KEY. Set it to enable contact email.");
@@ -22,8 +22,6 @@ export interface Contact{
 
 export const contactService = {
     sendMail: async (data: Contact) => {
-        if(process.env.NODE_ENV === 'test') return { id: 'mocked-id' };
-
         const { inquiryType, subject, message } = data;
         const resendClient = getResendClient();
 
@@ -46,6 +44,7 @@ export const contactService = {
 
         if(error) throw new Error(`Failed to send: ${error.message}`);
         if(responseData) return responseData;
+        if(process.env.NODE_ENV === 'test') return { id: 'mocked-id' };
 
         return responseData;
     }

--- a/backend/core/src/services/contact.services.ts
+++ b/backend/core/src/services/contact.services.ts
@@ -1,7 +1,17 @@
 import { Resend } from "resend";
 
-const api = process.env.NODE_ENV === "test" ? "dummy" : process.env.RESEND_API_KEY;
-const resend = new Resend(api);
+let resend: Resend | undefined;
+
+function getResendClient(): Resend {
+    const api = process.env.RESEND_API_KEY;
+
+    if (!api) {
+        throw new Error("Missing RESEND_API_KEY. Set it to enable contact email.");
+    }
+
+    resend ??= new Resend(api);
+    return resend;
+}
 
 //data we need to pass through
 export interface Contact{
@@ -12,7 +22,10 @@ export interface Contact{
 
 export const contactService = {
     sendMail: async (data: Contact) => {
+        if(process.env.NODE_ENV === 'test') return { id: 'mocked-id' };
+
         const { inquiryType, subject, message } = data;
+        const resendClient = getResendClient();
 
         const emailLoad = {
             from: "OptiGrid Support <onboarding@resend.dev>",
@@ -27,13 +40,12 @@ export const contactService = {
             <p>${message}</p>`,
         };
 
-        const resendResp = await resend.emails.send(emailLoad);
+        const resendResp = await resendClient.emails.send(emailLoad);
         const responseData = resendResp?.data;
         const error = resendResp?.error;
 
         if(error) throw new Error(`Failed to send: ${error.message}`);
         if(responseData) return responseData;
-        if(process.env.NODE_ENV === 'test') return { id: 'mocked-id' };
 
         return responseData;
     }

--- a/backend/core/src/services/user_auth.services.ts
+++ b/backend/core/src/services/user_auth.services.ts
@@ -26,6 +26,12 @@ type ProvisionedAuthUser = {
     cleanup: () => Promise<void>;
 };
 
+type AuthenticatedAuthUser = {
+    userId: string;
+    email: string;
+    accessToken: string;
+};
+
 // Service-role Supabase client for privileged auth admin actions (signup provisioning).
 function getSupabaseAdminClient() {
     const supabaseUrl = process.env.SUPABASE_URL;
@@ -75,6 +81,8 @@ function isSupabaseDuplicateUserError(error: { message?: string; code?: string }
     return (
         code === 'user_already_exists' ||
         message.includes('already registered') ||
+        message.includes('already been registered') ||
+        message.includes('has already been registered') ||
         message.includes('already exists')
     );
 }
@@ -214,6 +222,64 @@ async function provisionAuthUser(email: string, password: string): Promise<Provi
     };
 }
 
+async function authenticateAuthUser(email: string, password: string): Promise<AuthenticatedAuthUser> {
+    const supabase = getSupabaseAuthClient();
+    const { data, error } = await supabase.auth.signInWithPassword({
+        email,
+        password,
+    });
+
+    if (error) {
+        if (isSupabaseInvalidCredentialsError(error)) {
+            throw new Error('Invalid email or password');
+        }
+
+        throw new Error(`Failed to authenticate user: ${error.message}`);
+    }
+
+    const userId = data.user?.id;
+    if (!userId) {
+        throw new Error('Failed to authenticate user: missing user id.');
+    }
+
+    const accessToken = data.session?.access_token;
+    if (!accessToken) {
+        throw new Error('Failed to authenticate user: missing access token.');
+    }
+
+    return {
+        userId,
+        email: data.user?.email ?? email,
+        accessToken,
+    };
+}
+
+async function provisionOrResolveAuthUser(email: string, password: string): Promise<ProvisionedAuthUser> {
+    try {
+        return await provisionAuthUser(email, password);
+    } catch (error) {
+        if (!(error instanceof Error) || error.message !== USER_EXISTS_ERROR) {
+            throw error;
+        }
+
+        try {
+            const authUser = await authenticateAuthUser(email, password);
+
+            return {
+                userId: authUser.userId,
+                // This auth identity predates this signup attempt; do not delete it on profile-write failure.
+                cleanup: async () => {},
+            };
+        } catch (authError) {
+            if (authError instanceof Error && authError.message === 'Invalid email or password') {
+                throw new Error(USER_EXISTS_ERROR);
+            }
+
+            throw authError;
+        }
+    }
+}
+
 //This function is used for the signup logic
 export const signup = async (email: string, password: string, name: string) => {
     //we check if user exists, and if so he should login
@@ -225,7 +291,7 @@ export const signup = async (email: string, password: string, name: string) => {
     const lastName = otherNames.join(' ');
 
     // Prefer Supabase auth user id to satisfy schemas where users.user_id references auth.users.id.
-    const provisionedAuthUser = await provisionAuthUser(email, password);
+    const provisionedAuthUser = await provisionOrResolveAuthUser(email, password);
     
     const createData = {
         userId: provisionedAuthUser.userId,
@@ -258,33 +324,12 @@ export const signup = async (email: string, password: string, name: string) => {
 
 //this function is used for the login logic
 export const login = async (email: string, password: string) => {
-    const supabase = getSupabaseAuthClient();
     // Supabase verifies credentials; we no longer compare local password hashes in this service.
-    const { data, error } = await supabase.auth.signInWithPassword({
-        email,
-        password,
-    });
-
-    if (error) {
-        if (isSupabaseInvalidCredentialsError(error)) {
-            throw new Error('Invalid email or password');
-        }
-
-        throw new Error(`Failed to authenticate user: ${error.message}`);
-    }
-
-    const userId = data.user?.id;
-    if (!userId) {
-        throw new Error('Failed to authenticate user: missing user id.');
-    }
-    const accessToken = data.session?.access_token;
-    if (!accessToken) {
-        throw new Error('Failed to authenticate user: missing access token.');
-    }
+    const authUser = await authenticateAuthUser(email, password);
 
     // Resolve app profile by the authenticated Supabase user id.
-    const user = await prisma.user.findUnique({
-        where: { userId },
+    const existingUser = await prisma.user.findUnique({
+        where: { userId: authUser.userId },
         select: {
             userId: true,
             email: true,
@@ -293,12 +338,15 @@ export const login = async (email: string, password: string) => {
         },
     });
 
-    if (!user) {
-        throw new Error('Authenticated user profile not found.');
-    }
+    const user = existingUser ?? await createOrUpsertUser({
+        userId: authUser.userId,
+        email: authUser.email,
+        firstName: '',
+        lastName: '',
+    });
 
     return {
         user,
-        accessToken,
+        accessToken: authUser.accessToken,
     };
 };

--- a/frontend/app/favicon.ico/route.ts
+++ b/frontend/app/favicon.ico/route.ts
@@ -1,0 +1,13 @@
+const faviconSvg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="14" fill="#0b1f3a"/>
+  <path d="M18 42V22h8v20h-8Zm13 0V14h8v28h-8Zm13 0V27h8v15h-8Z" fill="#8fd7e8"/>
+</svg>`;
+
+export function GET() {
+	return new Response(faviconSvg, {
+		headers: {
+			"content-type": "image/svg+xml; charset=utf-8",
+			"cache-control": "public, max-age=86400",
+		},
+	});
+}

--- a/tests/integration/backend/core/login.integration.test.ts
+++ b/tests/integration/backend/core/login.integration.test.ts
@@ -80,8 +80,7 @@ describe('Login integration', () => {
 		expect(response.body.message).toBe('Email and password are required fields.');
 	});
 
-	it('returns 500 when Supabase auth succeeds but the local profile is missing', async () => {
-		const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+	it('repairs the local profile when Supabase auth succeeds but the profile is missing', async () => {
 		const signupPayload = {
 			email: uniqueEmail('missing-profile'),
 			password: 'StrongPass123!',
@@ -95,21 +94,32 @@ describe('Login integration', () => {
 		await client.connect();
 		try {
 			await client.query('delete from users where user_id = $1', [signupResponse.body.user.userId]);
-		} finally {
-			await client.end();
-		}
-
-		let response: request.Response;
-		try {
-			response = await request(harness.app).post('/auth/login').send({
+			const response = await request(harness.app).post('/auth/login').send({
 				email: signupPayload.email,
 				password: signupPayload.password,
 			});
-		} finally {
-			consoleErrorSpy.mockRestore();
-		}
 
-		expect(response.status).toBe(500);
-		expect(response.body.message).toBe('Internal server error');
+			expect(response.status).toBe(200);
+			expect(response.body.user).toEqual({
+				userId: signupResponse.body.user.userId,
+				email: signupPayload.email,
+				firstName: '',
+				lastName: '',
+			});
+			expect(response.body.accessToken).toEqual(expect.any(String));
+
+			const repairedProfile = await client.query('select user_id, email, first_name, last_name from users where user_id = $1', [
+				signupResponse.body.user.userId,
+			]);
+			expect(repairedProfile.rowCount).toBe(1);
+			expect(repairedProfile.rows[0]).toEqual({
+				user_id: signupResponse.body.user.userId,
+				email: signupPayload.email,
+				first_name: '',
+				last_name: '',
+			});
+		} finally {
+			await client.end();
+		}
 	});
 });

--- a/tests/unit/backend/user_auth.services.test.ts
+++ b/tests/unit/backend/user_auth.services.test.ts
@@ -8,6 +8,7 @@ jest.mock('../../../backend/core/src/lib/prisma', () => ({
     default: {
         user: {
             findUnique: jest.fn(),
+            upsert: jest.fn(),
         },
     },
 }));
@@ -22,6 +23,7 @@ jest.mock('@supabase/supabase-js', () => ({
 const mockedPrisma = prisma as unknown as {
     user: {
         findUnique: jest.Mock;
+        upsert: jest.Mock;
     };
 };
 
@@ -110,14 +112,22 @@ describe('User Authentication Service - Login', () => {
 
         await expect(authServices.login('test@testing.com', 'wrongpassword')).rejects.toThrow('Invalid email or password');
         expect(mockedPrisma.user.findUnique).not.toHaveBeenCalled();
+        expect(mockedPrisma.user.upsert).not.toHaveBeenCalled();
     });
 
-    it('should throw an error if authenticated profile is missing', async () => {
-        // Even with valid auth, missing local profile should fail explicitly.
+    it('should create a profile if authenticated profile is missing', async () => {
+        // Valid auth can repair a missing local app profile.
+        const repairedUser = {
+            userId: 'uuid-1234',
+            email: 'test@testing.com',
+            firstName: '',
+            lastName: '',
+        };
         mockSignInWithPassword.mockResolvedValue({
             data: {
                 user: {
                     id: 'uuid-1234',
+                    email: 'test@testing.com',
                 },
                 session: {
                     access_token: 'token-123',
@@ -126,7 +136,33 @@ describe('User Authentication Service - Login', () => {
             error: null,
         });
         mockedPrisma.user.findUnique.mockResolvedValue(null);
+        mockedPrisma.user.upsert.mockResolvedValue(repairedUser);
 
-        await expect(authServices.login('test@testing.com', 'password1234')).rejects.toThrow('Authenticated user profile not found.');
+        await expect(authServices.login('test@testing.com', 'password1234')).resolves.toEqual({
+            user: repairedUser,
+            accessToken: 'token-123',
+        });
+        expect(mockedPrisma.user.upsert).toHaveBeenCalledWith({
+            where: {
+                userId: 'uuid-1234',
+            },
+            create: {
+                userId: 'uuid-1234',
+                email: 'test@testing.com',
+                firstName: '',
+                lastName: '',
+            },
+            update: {
+                email: 'test@testing.com',
+                firstName: '',
+                lastName: '',
+            },
+            select: {
+                userId: true,
+                email: true,
+                firstName: true,
+                lastName: true,
+            },
+        });
     });
 });


### PR DESCRIPTION
## Description

This update improves Supabase auth handling so signup/login can recover when Supabase Auth and the app `users` profile table get out of sync.

Login now creates a missing app profile for a valid Supabase Auth user, and signup can resolve an existing Auth user when the provided credentials are valid.

## Changes

- Reconcile Supabase Auth users with local app profiles during signup/login.
- Lazy-load the Resend client so missing `RESEND_API_KEY` does not break test/runtime imports.
- Add ignore rules for local runtime, build, and cache artifacts.
- Add an OptiGrid favicon route.
