### PR TITLE
Security/mass assignment

### DIFF
--- a/backend/core/src/controllers/sensor.controller.ts
+++ b/backend/core/src/controllers/sensor.controller.ts
@@ -1,16 +1,13 @@
 import {Request, Response} from "express"
 import {forwardToIngestionService} from "../services/sensor.services"
+import {telemetrySchema} from "../validation/sensor.validation"
 
 // handing incoming sensor data from IoT devices
 export const handleSensorTelemetry = async (req: Request, res: Response): Promise<void> => {
     try{
-        const telemetryData = req.body;
+        //so I added the strict validation here before moving down pipeline and z unknown fields are rejected now
+        const telemetryData = telemetrySchema.parse(req.body);
 
-        //basic validation before moving down pipeline
-        if(!telemetryData.sensor_id || !telemetryData.building_id || !telemetryData.usage){
-            res.status(400).json({status: "error", message: "Missing required telemetry fields"});
-            return;
-        }
         // forward validated data to ingestion service (which sends to redis)
         const ingestionResponse = await forwardToIngestionService(telemetryData);
         res.status(200).json({
@@ -19,6 +16,10 @@ export const handleSensorTelemetry = async (req: Request, res: Response): Promis
         });
     }
     catch(error :any){
+        if(error.name === "ZodError"){
+            res.status(400).json({status: "error", message: "Invalid telemetry payload", details: error.errors});
+            return;
+        }
         console.error("Core API Gateway error forwarding sensor data: ", error.message);
         res.status(500).json({status: 'error', 'message': "Failed to process telemetry payload."});
     }

--- a/backend/core/src/controllers/user_preferences.controller.ts
+++ b/backend/core/src/controllers/user_preferences.controller.ts
@@ -1,6 +1,7 @@
 import { Request, Response } from "express";
 import prisma from "../lib/prisma";
 import { ThemePreference } from "@prisma/client";
+import { updateThemeSchema } from "../validation/user_preferences.validation";
 
 export async function getUserTheme(req: Request, res: Response) {
     const userId = req.user?.id; // No more (req as any)
@@ -16,14 +17,23 @@ export async function getUserTheme(req: Request, res: Response) {
 
 export async function updateUserTheme(req: Request, res: Response) {
     const userId = req.user?.id;
-    const { theme } = req.body;
 
     if (!userId) return res.status(401).json({ status: "error", message: "Unauthorized" });
 
-    await prisma.user.update({
-        where: { userId: userId },
-        data: { preferredTheme: theme.toUpperCase() as ThemePreference }
-    });
+    try {
+        const { theme } = updateThemeSchema.parse(req.body);
+        await prisma.user.update({
+            where: { userId: userId },
+            data: { preferredTheme: theme.toUpperCase() as ThemePreference }
+        });
 
-    return res.json({ status: "success" });
+        return res.json({ status: "success" });
+    } catch (error: any) {
+        if (error.name === "ZodError") {
+            return res.status(400).json({ status: "error", message: "Invalid theme payload", details: error.errors });
+        }
+
+        console.error("Theme updating error:", error);
+        return res.status(500).json({ status: "error", message: "Internal server error" });
+    }
 }

--- a/backend/core/src/middleware/auth.middleware.ts
+++ b/backend/core/src/middleware/auth.middleware.ts
@@ -88,9 +88,10 @@ export async function authenticateRequest(req: Request, res: Response, next: Nex
 			select: { tenantId: true },
 		});
 
+		//the tenant_id must come from our own DB only. so because supabase user_metadata is client-writable, we cannot trust it as users can self-assign a tenant
 		const userMetadata = {
 			...(data.user.user_metadata ?? {}),
-			tenant_id: profile?.tenantId ?? data.user.user_metadata?.tenant_id ?? "",
+			tenant_id: profile?.tenantId ?? "",
 		};
 
 		req.user = {

--- a/backend/core/src/routes/user_auth.routes.ts
+++ b/backend/core/src/routes/user_auth.routes.ts
@@ -1,6 +1,6 @@
 import { Router } from 'express';
 import { signup, login } from '../controllers/user_auth.controller';
-import { validateSignUp, signupSchema } from '../validation/user_auth.validation';
+import { validateSignUp, validateBody, signupSchema, loginSchema } from '../validation/user_auth.validation';
 
 const router = Router();
 
@@ -180,7 +180,7 @@ router.post('/signup', validateSignUp(signupSchema), signup);
  *                   type: string
  *                   example: Internal server error
  */
-router.post('/login', login)
+router.post('/login', validateBody(loginSchema), login)
 
 export default router;
 

--- a/backend/core/src/routes/user_preferences.routes.ts
+++ b/backend/core/src/routes/user_preferences.routes.ts
@@ -41,7 +41,7 @@ const router = Router();
  *             properties:
  *               theme:
  *                 type: string
- *                 enum: [light, dark]
+ *                 enum: [light, dark, system]
  *                 example: dark
  *     responses:
  *       200:

--- a/backend/core/src/validation/sensor.validation.ts
+++ b/backend/core/src/validation/sensor.validation.ts
@@ -1,0 +1,17 @@
+import { z } from 'zod';
+
+// we also need a strict schema here as well so unknown fields are rejected and never forwarded to the ingestion pipeline
+export const telemetrySchema = z.object({
+    sensor_id: z.string().min(1, "sensor_id is required").max(255),
+    building_id: z.string().min(1, "building_id is required").max(255),
+    
+    //devices may send usage as a number or as a numeric string
+    usage: z.preprocess(
+        (value) => (typeof value === 'string' && value.trim() !== '' ? Number(value) : value),
+        z.number({ error: "usage must be a number" }).finite("usage must be a finite number"),
+    ),
+    meter_id: z.string().max(255).optional(),
+    timestamp: z.string().datetime({ offset: true, message: "timestamp must be an ISO-8601 date-time string" }).optional(),
+}).strict();
+
+export type TelemetryPayload = z.infer<typeof telemetrySchema>;

--- a/backend/core/src/validation/user_auth.validation.ts
+++ b/backend/core/src/validation/user_auth.validation.ts
@@ -11,7 +11,13 @@ export const signupSchema = z.object({
             message:'Password must include at least one uppercase letter, one number, and one special character',
         }),
     name: z.string().min(3, { message: 'Name must be 3 or more characters' }),
-});
+}).strict();
+
+// we need a schema here to validate login credentials
+export const loginSchema = z.object({
+    email: z.string().email({ message: 'Invalid email address' }),
+    password: z.string().min(1, { message: 'Password is required' }),
+}).strict();
 
 
 export const validateSignUp = (schema: ZodTypeAny) => {
@@ -38,3 +44,6 @@ export const validateSignUp = (schema: ZodTypeAny) => {
         }
     };
 };
+
+//this is a generic alias. this middleware validates any body schema not just signup
+export const validateBody = validateSignUp;

--- a/backend/core/src/validation/user_auth.validation.ts
+++ b/backend/core/src/validation/user_auth.validation.ts
@@ -11,6 +11,10 @@ export const signupSchema = z.object({
             message:'Password must include at least one uppercase letter, one number, and one special character',
         }),
     name: z.string().min(3, { message: 'Name must be 3 or more characters' }),
+    roleType: z.preprocess(
+        (value) => (typeof value === 'string' ? value.toUpperCase() : value),
+        z.enum(['ADMIN', 'BUILDING_MANAGER', 'VIEWER'])
+    ).optional(),
 }).strict();
 
 // we need a schema here to validate login credentials
@@ -18,10 +22,6 @@ export const loginSchema = z.object({
     email: z.string().email({ message: 'Invalid email address' }),
     password: z.string().min(1, { message: 'Password is required' }),
 }).strict();
-        roleType: z.preprocess(
-            (value) => (typeof value === 'string' ? value.toUpperCase() : value),
-            z.enum(['ADMIN', 'BUILDING_MANAGER', 'VIEWER'])
-        ).optional(),});
 
 
 export const validateSignUp = (schema: ZodTypeAny) => {

--- a/backend/core/src/validation/user_preferences.validation.ts
+++ b/backend/core/src/validation/user_preferences.validation.ts
@@ -1,0 +1,10 @@
+import { z } from 'zod';
+
+//this have been added to validate theme against the  ThemePreference prisma enum values to make sure the request body is in a specific structure
+export const updateThemeSchema = z.object({
+    theme: z.enum(['light', 'dark', 'system'], {
+        error: "Theme must be light, dark, or system only.",
+    }),
+}).strict();
+
+export type UpdateThemePayload = z.infer<typeof updateThemeSchema>;

--- a/tests/integration/backend/core/login.integration.test.ts
+++ b/tests/integration/backend/core/login.integration.test.ts
@@ -77,7 +77,8 @@ describe('Login integration', () => {
 		});
 
 		expect(response.status).toBe(400);
-		expect(response.body.message).toBe('Email and password are required fields.');
+		expect(response.body.message).toBe('Validation error');
+		expect(response.body.errors).toEqual(expect.arrayContaining([expect.objectContaining({ field: 'password' })]),);
 	});
 
 	it('repairs the local profile when Supabase auth succeeds but the profile is missing', async () => {

--- a/tests/integration/backend/core/sensor.integration.test.ts
+++ b/tests/integration/backend/core/sensor.integration.test.ts
@@ -59,10 +59,29 @@ describe('Sensor API Integration', () => {
 			});
 
 		expect(response.status).toBe(400);
-		expect(response.body).toEqual({
+		expect(response.body).toEqual(expect.objectContaining({
 			status: 'error',
-			message: 'Missing required telemetry fields',
-		});
+			message: 'Invalid telemetry payload',
+		}));
+		expect(mockedForwardToIngestionService).not.toHaveBeenCalled();
+	});
+
+	it('returns 400 when the payload contains unexpected fields', async () => {
+		const response = await request(harness.app)
+			.post('/api/sensors/data')
+			.send({
+				building_id: '11111111-1111-4111-8111-111111111111',
+				sensor_id: '22222222-2222-4222-8222-222222222222',
+				usage: 42.5,
+				hardware_auth_token: 'attack',
+			});
+
+		expect(response.status).toBe(400);
+
+		expect(response.body).toEqual(expect.objectContaining({
+			status: 'error',
+			message: 'Invalid telemetry payload',
+		}));
 		expect(mockedForwardToIngestionService).not.toHaveBeenCalled();
 	});
 

--- a/tests/unit/backend/sensor.controller.test.ts
+++ b/tests/unit/backend/sensor.controller.test.ts
@@ -37,10 +37,33 @@ describe('sensor controller unit tests', () => {
 
         //Assert
         expect(mockRes.status).toHaveBeenCalledWith(400);
-        expect(mockRes.json).toHaveBeenCalledWith({
+        expect(mockRes.json).toHaveBeenCalledWith(expect.objectContaining({
             status: 'error',
-            message: 'Missing required telemetry fields'
-        });
+            message: 'Invalid telemetry payload'
+        }));
+        expect(mockedForwardToIngestionService).not.toHaveBeenCalled();
+    });
+
+    it('rejects payloads carrying unexpected fields to prevent mass assignment', async () => {
+        // arrange
+        mockReq = {
+            body: {
+                sensor_id: 'sensor-001',
+                building_id: 'building-001',
+                usage: 412.5,
+                lifecycle_state: 'ACTIVE',
+                is_admin: true
+            }
+        };
+        // act
+        await handleSensorTelemetry(mockReq as Request, mockRes as Response);
+
+        // assert
+        expect(mockRes.status).toHaveBeenCalledWith(400);
+        expect(mockRes.json).toHaveBeenCalledWith(expect.objectContaining({
+            status: 'error',
+            message: 'Invalid telemetry payload'
+        }));
         expect(mockedForwardToIngestionService).not.toHaveBeenCalled();
     });
 
@@ -59,7 +82,12 @@ describe('sensor controller unit tests', () => {
         await handleSensorTelemetry(mockReq as Request, mockRes as Response);
 
         // Assert
-        expect(mockedForwardToIngestionService).toHaveBeenCalledWith(mockReq.body);
+        //the numeric string usage values get converted to numbers before forwarding here
+        expect(mockedForwardToIngestionService).toHaveBeenCalledWith({
+            sensor_id: 'sensor-001',
+            building_id: 'building-001',
+            usage: 412.5
+        });
         expect(mockRes.status).toHaveBeenCalledWith(200);
         expect(mockRes.json).toHaveBeenCalledWith({
             status: 'success',

--- a/tests/unit/backend/signup.validation.test.ts
+++ b/tests/unit/backend/signup.validation.test.ts
@@ -1,4 +1,4 @@
-import { validateSignUp, signupSchema } from '../../../backend/core/src/validation/user_auth.validation';
+import { validateSignUp, validateBody, loginSchema, signupSchema } from '../../../backend/core/src/validation/user_auth.validation';
 
 /**so this test suite is for signup validation, we test that valid payloads pass through to next()
 and invalid payload return proper errors with 400 status**/
@@ -62,5 +62,50 @@ describe('signup validation', () => {
 				]),
 			}),
 		);
+	});
+
+	it('rejects signup payloads carrying unexpected fields to guard against mass assignment', async () => {
+		//Arrange
+		const req = {
+			body: {
+				email: 'user@example.com',
+				password: 'SecurePass123!',
+				name: 'Jane Doe',
+				role: 'admin',
+				tenant_id: '11111111-1111-4111-8111-111111111111',
+			},
+		} as any;
+
+		const res = {
+			status: jest.fn().mockReturnThis(),
+			json: jest.fn(),
+		} as any;
+		const next = jest.fn();
+
+		// Act
+		await validateSignUp(signupSchema)(req, res, next);
+
+		// Assert
+		expect(next).not.toHaveBeenCalled();
+		expect(res.status).toHaveBeenCalledWith(400);
+	});
+
+	it('passes valid login payloads to and rejects any extra fields', async () => {
+		const res = {
+			status: jest.fn().mockReturnThis(),
+			json: jest.fn(),
+		} as any;
+
+		
+		const validReq = { body: { email: 'user@example.com', password: 'SecurePass123!' } } as any;
+		const validNext = jest.fn();
+		await validateBody(loginSchema)(validReq, res, validNext);
+		expect(validNext).toHaveBeenCalledTimes(1);
+		const invalidReq = { body: { email: 'user@example.com', password: 'SecurePass123!', is_admin: true } } as any;
+		const invalidNext = jest.fn();
+		await validateBody(loginSchema)(invalidReq, res, invalidNext);
+
+		expect(invalidNext).not.toHaveBeenCalled();
+		expect(res.status).toHaveBeenCalledWith(400);
 	});
 });

--- a/tests/unit/backend/user_preferences.test.ts
+++ b/tests/unit/backend/user_preferences.test.ts
@@ -9,8 +9,13 @@ jest.mock("../../../backend/core/src/lib/prisma", () => ({
 }));
 
 describe("User Preferences Controller", () => {
-    const mockReq = { user: { id: "user-123" }, body: {} } as any;
-    const mockRes = { json: jest.fn(), status: jest.fn().mockReturnThis() } as any;
+    let mockReq: any;
+    let mockRes: any;
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockReq = { user: { id: "user-123" }, body: {} };
+        mockRes = { json: jest.fn(), status: jest.fn().mockReturnThis() };
+    });
 
     it("should fetch theme correctly", async () => {
         (prisma.user.findUnique as jest.Mock).mockResolvedValue({ preferredTheme: "DARK" });
@@ -25,5 +30,27 @@ describe("User Preferences Controller", () => {
         expect(prisma.user.update).toHaveBeenCalledWith(
             expect.objectContaining({ data: { preferredTheme: "LIGHT" } })
         );
+    });
+
+    it("should reject an invalid theme value with a 400 code", async () => {
+        mockReq.body = { theme: "red" };
+        await updateUserTheme(mockReq, mockRes);
+        expect(mockRes.status).toHaveBeenCalledWith(400);
+        expect(mockRes.json).toHaveBeenCalledWith(expect.objectContaining({ status: "error", message: "Invalid theme payload" }));
+        expect(prisma.user.update).not.toHaveBeenCalled();
+    });
+
+    it("should reject a missing theme field with a 400 instead of just crashing", async () => {
+        mockReq.body = {};
+        await updateUserTheme(mockReq, mockRes);
+        expect(mockRes.status).toHaveBeenCalledWith(400);
+        expect(prisma.user.update).not.toHaveBeenCalled();
+    });
+
+    it("should reject payloads with any unexpected extra fields", async () => {
+        mockReq.body = { theme: "dark", role: "admin" };
+        await updateUserTheme(mockReq, mockRes);
+        expect(mockRes.status).toHaveBeenCalledWith(400);
+        expect(prisma.user.update).not.toHaveBeenCalled();
     });
 });


### PR DESCRIPTION
This PR Hardens the API against mass assignment. tenant_id is now resolved from the DB only (not Supabase metadata which is client writeable). The theme, sensor telemetry, signup, and login endpoints all enforce strict Zod schemas that reject unknown fields instead of passing them through.