### PR TITLE
Compute supplemental energy summary metrics

### DIFF
--- a/backend/core/src/services/building.services.ts
+++ b/backend/core/src/services/building.services.ts
@@ -24,6 +24,101 @@ function timeRangeToDays(timeRange: string): number {
   return daysByRange[timeRange] ?? 30;
 }
 
+function isUnavailableMetricSource(error: unknown): boolean {
+  const err = error as { code?: string; message?: string };
+  const message = err.message?.toLowerCase() ?? '';
+
+  return (
+    err.code === '42P01' ||
+    err.code === '42703' ||
+    message.includes('relation') && message.includes('does not exist') ||
+    message.includes('column') && message.includes('does not exist')
+  );
+}
+
+async function countBuildingAnomalyAlerts(buildingId: string): Promise<number | null> {
+  try {
+    const rows = await prisma.$queryRaw<Array<{ count: number | bigint | string }>>`
+      SELECT COUNT(*) AS count
+      FROM anomalies anomaly
+      INNER JOIN sensors sensor
+        ON sensor.sensor_id::text = anomaly.sensor_id::text
+      WHERE sensor.building_id::text = ${buildingId}
+    `;
+
+    return Math.trunc(toFiniteNumber(rows[0]?.count, 0));
+  } catch (error) {
+    if (isUnavailableMetricSource(error)) {
+      return null;
+    }
+
+    throw error;
+  }
+}
+
+const recommendationSavingsColumns = [
+  'cost_saved_by_recommendations_zar',
+  'estimated_savings_zar',
+  'estimated_monthly_savings_zar',
+  'estimated_monthly_savings',
+  'estimated_savings',
+  'savings_zar',
+  'monthly_savings_zar',
+] as const;
+
+async function sumImplementedRecommendationSavings(buildingId: string): Promise<number | null> {
+  try {
+    const columns = await prisma.$queryRawUnsafe<Array<{ column_name: string }>>(
+      `
+      SELECT column_name
+      FROM information_schema.columns
+      WHERE table_schema = current_schema()
+        AND table_name = 'optimisation_recommendations'
+      `,
+    );
+
+    const availableColumns = new Set(columns.map((column) => column.column_name));
+    const savingsColumn = recommendationSavingsColumns.find((column) => availableColumns.has(column));
+
+    if (!savingsColumn) {
+      return null;
+    }
+
+    const statusFilter = availableColumns.has('status')
+      ? "AND LOWER(COALESCE(status::text, '')) IN ('implemented', 'completed', 'accepted', 'followed', 'done')"
+      : '';
+    const rows = await prisma.$queryRawUnsafe<Array<{ total: number | string | null }>>(
+      `
+      SELECT COALESCE(SUM("${savingsColumn}"::numeric), 0) AS total
+      FROM optimisation_recommendations
+      WHERE building_id::text = $1
+      ${statusFilter}
+      `,
+      buildingId,
+    );
+
+    return roundMetric(toFiniteNumber(rows[0]?.total, 0));
+  } catch (error) {
+    if (isUnavailableMetricSource(error)) {
+      return null;
+    }
+
+    throw error;
+  }
+}
+
+async function getBuildingEnergySupplementalMetrics(buildingId: string) {
+  const [totalAnomalyAlerts, costSavedByRecommendationsZar] = await Promise.all([
+    countBuildingAnomalyAlerts(buildingId),
+    sumImplementedRecommendationSavings(buildingId),
+  ]);
+
+  return {
+    totalAnomalyAlerts,
+    costSavedByRecommendationsZar,
+  };
+}
+
 // handle building creation, updating, deletion, and others here
 export interface buildingPayload {
   tenant_id?: string;
@@ -178,7 +273,10 @@ export const getBuildingEnergyConsumptionDetails = async (
     throw new Error('Building not found');
   }
 
-  const usageDetails = await queryUsageDetails(buildingId, timeRange);
+  const [usageDetails, supplementalMetrics] = await Promise.all([
+    queryUsageDetails(buildingId, timeRange),
+    getBuildingEnergySupplementalMetrics(buildingId),
+  ]);
   const totalKwh = toFiniteNumber(usageDetails.total_kwh);
   const totalCostUsd = toFiniteNumber(usageDetails.total_cost_usd);
   const rawTotalCostZar = toFiniteNumber(usageDetails.total_cost_zar);
@@ -205,8 +303,8 @@ export const getBuildingEnergyConsumptionDetails = async (
     total_cost_usd: roundMetric(totalCostUsd),
     cost_per_kwh: totalKwh > 0 ? roundMetric(totalCostZar / totalKwh) : 0,
     eui: hasSquareFootage ? roundMetric(totalKwh / sqFt) : null,
-    total_anomaly_alerts: null,
-    cost_saved_by_recommendations_zar: null,
+    total_anomaly_alerts: supplementalMetrics.totalAnomalyAlerts,
+    cost_saved_by_recommendations_zar: supplementalMetrics.costSavedByRecommendationsZar,
   };
 };
 

--- a/tests/unit/backend/building.service.test.ts
+++ b/tests/unit/backend/building.service.test.ts
@@ -7,6 +7,8 @@ jest.mock('../../../backend/core/src/lib/prisma', () => ({
 	__esModule: true,
 	default: {
 		$transaction: jest.fn(),
+		$queryRaw: jest.fn(),
+		$queryRawUnsafe: jest.fn(),
 		building: {
 			findMany: jest.fn(),
 		},
@@ -15,6 +17,8 @@ jest.mock('../../../backend/core/src/lib/prisma', () => ({
 
 const mockedPrisma = prisma as unknown as {
     $transaction: jest.Mock;
+	$queryRaw: jest.Mock;
+	$queryRawUnsafe: jest.Mock;
     userBuildingAccess: {
         findUnique: jest.Mock;
     };
@@ -489,6 +493,15 @@ describe('getBuildingEnergyConsumptionDetails', () => {
 	beforeEach(() => {
 		(mockedPrisma as any).userBuildingAccess = { findUnique: jest.fn() };
 		(mockedPrisma as any).building = { findUnique: jest.fn() };
+		(mockedPrisma as any).$queryRaw = jest.fn().mockResolvedValue([{ count: 2 }]);
+		(mockedPrisma as any).$queryRawUnsafe = jest
+			.fn()
+			.mockResolvedValueOnce([
+				{ column_name: 'building_id' },
+				{ column_name: 'status' },
+				{ column_name: 'estimated_monthly_savings' },
+			])
+			.mockResolvedValueOnce([{ total: 350.456 }]);
 	});
 
 	afterEach(() => {
@@ -530,12 +543,40 @@ describe('getBuildingEnergyConsumptionDetails', () => {
 			total_cost_usd: 45,
 			cost_per_kwh: 2,
 			eui: 0.75,
-			total_anomaly_alerts: null,
-			cost_saved_by_recommendations_zar: null,
+			total_anomaly_alerts: 2,
+			cost_saved_by_recommendations_zar: 350.46,
 		});
 		expect(result.peak_usage_times).toEqual([
 			{ timestamp: '2026-07-10T08:00:00Z', kwh: 120.35 },
 		]);
+	});
+
+	it('returns_null_supplemental_metrics_when_tables_are_unavailable', async () => {
+		(mockedPrisma as any).userBuildingAccess.findUnique.mockResolvedValue({
+			user_id: mockUserId,
+			building_id: mockBuildingId,
+		});
+		(mockedPrisma as any).building.findUnique.mockResolvedValue({
+			building_id: mockBuildingId,
+			building_name: 'Energy Tower',
+			building_type: 'Commercial',
+			timezone: 'Africa/Johannesburg',
+			square_footage: 1200,
+			lifecycle_state: 'ACTIVE',
+		});
+		mockedInflux.queryUsageDetails.mockResolvedValue({
+			total_kwh: 900,
+			total_cost_usd: 45,
+			total_cost_zar: 1800,
+			peak_usage_times: [],
+		});
+		(mockedPrisma as any).$queryRaw = jest.fn().mockRejectedValue(Object.assign(new Error('relation "anomalies" does not exist'), { code: '42P01' }));
+		(mockedPrisma as any).$queryRawUnsafe = jest.fn().mockRejectedValue(Object.assign(new Error('relation "optimisation_recommendations" does not exist'), { code: '42P01' }));
+
+		const result = await getBuildingEnergyConsumptionDetails(mockUserId, mockBuildingId, '30d');
+
+		expect(result.total_anomaly_alerts).toBeNull();
+		expect(result.cost_saved_by_recommendations_zar).toBeNull();
 	});
 
 	it('throws_access_denied_when_the_user_has_no_building_access', async () => {


### PR DESCRIPTION
## Summary

Replaces hardcoded `null` values in the building energy consumption summary with computed supplemental metrics.

## Changes

- Counts building anomaly alerts from `anomalies` joined through `sensors`.
- Sums implemented recommendation savings when `optimisation_recommendations` has a supported savings column.
- Keeps graceful `null` fallbacks when optional metric tables or columns are unavailable.
- Adds unit tests for computed metrics and fallback behavior.

## Verification

- `pnpm --filter @optigrid/core test -- --runTestsByPath ../../tests/unit/backend/building.controller.test.ts ../../tests/unit/backend/building.service.test.ts ../../tests/unit/backend/building.validation.test.ts ../../tests/unit/backend/influx.test.ts --runInBand`
- `pnpm --filter @optigrid/core build`